### PR TITLE
global(RootStyle) blinking issue fixed

### DIFF
--- a/app/src/_global/index.ts
+++ b/app/src/_global/index.ts
@@ -1,8 +1,7 @@
 "use client";
 
-import RootStyle from "./lib/styledComponents/RootStyle";
-import StyledComponentsRegistry from "./lib/styledComponents/Registry";
-import GlobalThemeProvider from "./provider/ThemeProvier";
+import StyledComponentsRegistryProvider from "./provider/styledComponents/RegistryProvider";
+import GlobalThemeProvider from "./provider/styledComponents/ThemeProvier";
 import { ibmPlex } from "./fonts";
 
-export { RootStyle, StyledComponentsRegistry, GlobalThemeProvider, ibmPlex };
+export { StyledComponentsRegistryProvider, GlobalThemeProvider, ibmPlex };

--- a/app/src/_global/provider/styledComponents/RegistryProvider.tsx
+++ b/app/src/_global/provider/styledComponents/RegistryProvider.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+import { createGlobalStyle } from "styled-components";
+
+export default function StyledComponentsRegistryProvider({ children }: { children: React.ReactNode }) {
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    console.log(styles);
+    styledComponentsStyleSheet.instance.clearTag();
+
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      <RootStyle />
+      {children}
+    </StyleSheetManager>
+  );
+}
+
+function RootStyle() {
+  const GlobalStyle = createGlobalStyle`
+  :root {
+    --background: #ffffff;
+    --foreground: #171717;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --background: #0a0a0a;
+      --foreground: #ededed;
+    }
+  }
+
+  html,
+  body {
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
+
+  body {
+    color: var(--foreground);
+    background: var(--background);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  button {
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html {
+      color-scheme: dark;
+    }
+  }
+`;
+
+  return <GlobalStyle />;
+}

--- a/app/src/_global/provider/styledComponents/ThemeProvier.tsx
+++ b/app/src/_global/provider/styledComponents/ThemeProvier.tsx
@@ -1,0 +1,32 @@
+import { DefaultTheme, ThemeProvider } from "styled-components";
+
+declare module "styled-components" {
+  export interface DefaultTheme {
+    color: {
+      "--gray-980": "#1a1818";
+      "--gray-950": "#0f0f0f";
+      "--gray-700": "#5d5d5d";
+      "--gray-400": "#b4b4b4";
+      "--gray-50": "#fcfcf9";
+      "--white": "#ffffff";
+      "--off-white": "#f3f3ed";
+    };
+  }
+}
+
+const theme: DefaultTheme = {
+  fontSize: {},
+  color: {
+    "--gray-980": "#1a1818",
+    "--gray-950": "#0f0f0f",
+    "--gray-700": "#5d5d5d",
+    "--gray-400": "#b4b4b4",
+    "--gray-50": "#fcfcf9",
+    "--white": "#ffffff",
+    "--off-white": "#f3f3ed",
+  },
+};
+
+export default function GlobalThemeProvider({ children }: Readonly<{ children: React.ReactNode }>) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -9,12 +9,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <G.GlobalThemeProvider>
-      <G.RootStyle />
       <html lang="ko">
         <head></head>
-        <body className={G.ibmPlex.variable} suppressHydrationWarning={true}>
-          <G.StyledComponentsRegistry>{children}</G.StyledComponentsRegistry>
-        </body>
+        <G.StyledComponentsRegistryProvider>
+          <body className={G.ibmPlex.variable} suppressHydrationWarning={true}>
+            {children}
+          </body>
+        </G.StyledComponentsRegistryProvider>
       </html>
     </G.GlobalThemeProvider>
   );

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -21,7 +21,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@/comps": ["./src/_components/index.ts"],
-      "@/global": ["./src/_global/index.ts"]
+      "@/global": ["./src/_global/index.ts"],
+      "@/constants": ["./src/_global/constants/index.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
- Styled-Components의 [Registry가 생기는 분기]와 [RootStyle이 생기는 분기]가 맞지 않음으로 blinking 이슈가 발생함.
- 기존 RootStyle 모듈을 styledComponents/Registry 모듈로 옮긴 후 window is defined일 때 같이 return으로 해결
- useServerInsertedHTML 훅 더 알아보기

- _global/index.ts(re-export file)에 RootStyle.ts 삭제 반영
- constants import alias 추가